### PR TITLE
ConfigurationProducer fix, additional tests

### DIFF
--- a/core/src/main/java/org/jboss/set/mjolnir/archive/batch/MembershipRemovalBatchlet.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/batch/MembershipRemovalBatchlet.java
@@ -214,6 +214,7 @@ public class MembershipRemovalBatchlet extends AbstractBatchlet {
 
         removal.setStatus(RemovalStatus.COMPLETED);
         em.persist(removal);
+        logger.infof("Removal batchlet completed successfully.");
         return true;
     }
 

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/configuration/ConfigurationProducer.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/configuration/ConfigurationProducer.java
@@ -50,8 +50,10 @@ public class ConfigurationProducer {
                     case UNSUBSCRIBE_USERS:
                         boolean boolValue = Boolean.parseBoolean(value);
                         configurationBuilder.setUnsubscribeUsers(boolValue);
+                        break;
                     case REPORTING_EMAIL:
                         configurationBuilder.setReportingEmail(value);
+                        break;
                     default:
                         logger.infof("Skipping configuration parameter %s", name);
                 }

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/configuration/ConfigurationProducer.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/configuration/ConfigurationProducer.java
@@ -3,6 +3,7 @@ package org.jboss.set.mjolnir.archive.configuration;
 import org.eclipse.egit.github.core.client.GitHubClient;
 import org.jboss.logging.Logger;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.sql.DataSource;
@@ -13,9 +14,6 @@ import java.sql.SQLException;
 
 /**
  * Loads configuration from a database.
- *
- * Since the default CDI scope (@Dependent) is currently used, a new Configuration instance is created for every
- * injection - i.e. configuration is reloaded during each batch execution.
  */
 public class ConfigurationProducer {
 
@@ -30,6 +28,7 @@ public class ConfigurationProducer {
     private DataSource dataSource;
 
     @Produces
+    @ApplicationScoped
     public Configuration createConfiguration() {
         try (Connection connection = dataSource.getConnection()) {
             PreparedStatement stmt = connection.prepareStatement("select param_name, param_value from application_parameters");

--- a/dbscripts/create.sql
+++ b/dbscripts/create.sql
@@ -16,7 +16,6 @@ create sequence sq_repository_forks;
 create table repository_forks (
     id bigint not null,
     user_removal_id bigint not null,
-    archived timestamp,
     created timestamp,
     repository_name varchar(255),
     repository_url varchar(255),

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -17,5 +17,16 @@
             <artifactId>hibernate-entitymanager</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/RepositoryFork.java
+++ b/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/RepositoryFork.java
@@ -44,8 +44,6 @@ public class RepositoryFork {
     @CreationTimestamp
     private Timestamp created;
 
-    private Timestamp archived;
-
     public Long getId() {
         return id;
     }
@@ -98,11 +96,4 @@ public class RepositoryFork {
         this.created = created;
     }
 
-    public Timestamp getArchived() {
-        return archived;
-    }
-
-    public void setArchived(Timestamp archived) {
-        this.archived = archived;
-    }
 }

--- a/domain/src/test/java/org/jboss/set/mjolnir/archive/domain/RemovalLogTestCase.java
+++ b/domain/src/test/java/org/jboss/set/mjolnir/archive/domain/RemovalLogTestCase.java
@@ -1,0 +1,28 @@
+package org.jboss.set.mjolnir.archive.domain;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemovalLogTestCase {
+
+    @Test
+    public void testSettingStackTrace() {
+        RemovalLog log = new RemovalLog();
+
+        try {
+            try {
+                throw new Exception("Cause");
+            } catch (Exception e) {
+                throw new Exception("Wrapping", e);
+            }
+        } catch (Exception e) {
+            log.setStackTrace(e);
+        }
+
+        assertThat(log.getStackTrace())
+                .contains("Caused by:")
+                .contains("Exception: Wrapping")
+                .contains("Exception: Cause");
+    }
+}


### PR DESCRIPTION
* Fix missing break statements in ConfigurationProducer and switch scope to @ApplicationScoped,
* additional test cases,
* remove "archive" field in RepositoryFork.