### PR TITLE
Fix scheduler transaction management

### DIFF
--- a/core/src/main/java/org/jboss/set/mjolnir/archive/mail/ReportScheduler.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/mail/ReportScheduler.java
@@ -9,6 +9,8 @@ import org.jboss.set.mjolnir.archive.mail.report.WhitelistedUsersWithoutLdapRepo
 
 import javax.ejb.Schedule;
 import javax.ejb.Singleton;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
 import javax.inject.Inject;
 import javax.mail.MessagingException;
 import javax.naming.NamingException;
@@ -17,6 +19,7 @@ import java.sql.Timestamp;
 import java.util.*;
 
 @Singleton
+@TransactionManagement(TransactionManagementType.BEAN) // do not open managed transaction
 public class ReportScheduler {
 
     private Logger logger = Logger.getLogger(getClass());

--- a/webapp/src/main/java/org/jboss/mjolnir/archive/service/webapp/JobScheduler.java
+++ b/webapp/src/main/java/org/jboss/mjolnir/archive/service/webapp/JobScheduler.java
@@ -10,12 +10,15 @@ import javax.batch.runtime.BatchRuntime;
 import javax.ejb.Schedule;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Properties;
 
 @Singleton
 @Startup
+@TransactionManagement(TransactionManagementType.BEAN) // do not open managed transaction
 public class JobScheduler {
 
     private final Logger logger = Logger.getLogger(getClass());


### PR DESCRIPTION
Make scheduling EJBs use bean managed transaction, to avoid a managed transaction being opened by default. Opened managed transaction prevents resource local transaction from being opened.