### PR TITLE
SET-243 Treat github names as case-insensitive

### DIFF
--- a/core/src/main/java/org/jboss/set/mjolnir/archive/GitArchiveRepository.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/GitArchiveRepository.java
@@ -10,6 +10,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+/**
+ * Defines basic operations for fetching remote repositories.
+ */
 public class GitArchiveRepository {
 
     private Git git;

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/github/GitHubDiscoveryBean.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/github/GitHubDiscoveryBean.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
  */
 public class GitHubDiscoveryBean {
 
-    private RepositoryService repositoryService;
+    final private RepositoryService repositoryService;
 
     @Inject
     public GitHubDiscoveryBean(GitHubClient client) {
@@ -41,7 +41,7 @@ public class GitHubDiscoveryBean {
         for (Repository sourceRepository : privateRepositories) {
             List<Repository> forks = repositoryService.getForks(sourceRepository);
             forks.stream()
-                    .filter(fork -> githubUser.equals(fork.getOwner().getLogin()))
+                    .filter(fork -> githubUser.toLowerCase().equals(fork.getOwner().getLogin().toLowerCase()))
                     .peek(repository -> repository.setSource(sourceRepository)) // set organization's repository as the source repository
                     .forEach(userRepositories::add);
         }

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBean.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBean.java
@@ -172,16 +172,13 @@ public class LdapScanningBean {
     }
 
     private static boolean containsRegisteredUser(String member, List<RegisteredUser> registeredUsers) {
-        boolean isMember = false;
-
         for (RegisteredUser registeredUser : registeredUsers) {
-            isMember = member.equals(registeredUser.getGithubName());
-
-            if (isMember)
-                break;
+            if (registeredUser.getGithubName() != null
+                    && member.toLowerCase().equals(registeredUser.getGithubName().toLowerCase())) {
+                return true;
+            }
         }
-
-        return isMember;
+        return false;
     }
 
     /**

--- a/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/RegisteredUser.java
+++ b/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/RegisteredUser.java
@@ -17,7 +17,7 @@ import javax.persistence.Table;
         @NamedQuery(name = RegisteredUser.FIND_ALL, query = "SELECT u FROM RegisteredUser u"),
         @NamedQuery(name = RegisteredUser.FIND_WHITELISTED, query = "SELECT u FROM RegisteredUser u WHERE u.whitelisted IS TRUE"),
         @NamedQuery(name = RegisteredUser.FIND_BY_KRB_NAME, query = "SELECT u FROM RegisteredUser u WHERE u.kerberosName = :krbName"),
-        @NamedQuery(name = RegisteredUser.FIND_BY_GITHUB_NAME, query = "SELECT u FROM RegisteredUser u WHERE u.githubName = :githubName")
+        @NamedQuery(name = RegisteredUser.FIND_BY_GITHUB_NAME, query = "SELECT u FROM RegisteredUser u WHERE LOWER(u.githubName) = LOWER(:githubName)")
 })
 @Entity
 @Table(name = "users")
@@ -28,6 +28,7 @@ public class RegisteredUser {
     public static final String FIND_BY_KRB_NAME = "RegisteredUser.findByKrbName";
     public static final String FIND_BY_GITHUB_NAME = "RegisteredUser.findByGitHubName";
 
+    @SuppressWarnings("unused")
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sq_users")
     @SequenceGenerator(name = "sq_users", sequenceName = "sq_users", allocationSize = 1)

--- a/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/repositories/RegisteredUserRepositoryBean.java
+++ b/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/repositories/RegisteredUserRepositoryBean.java
@@ -26,7 +26,7 @@ public class RegisteredUserRepositoryBean {
 
     public Optional<RegisteredUser> findByGitHubUsername(String username) {
         TypedQuery<RegisteredUser> query = em.createNamedQuery(RegisteredUser.FIND_BY_GITHUB_NAME, RegisteredUser.class);
-        query.setParameter("githubName", username);
+        query.setParameter("githubName", username.toLowerCase());
         return findSingleResult(query);
     }
 }


### PR DESCRIPTION
Currently github names are not matched correctly when we register users with different case characters.