### PR TITLE
Allow to archive unregistered users

### DIFF
--- a/core/src/main/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBean.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBean.java
@@ -194,7 +194,7 @@ public class LdapScanningBean {
     private Set<String> getExistingUserNamesToProcess() {
         List<UserRemoval> existingRemovalsToProcess =
                 em.createNamedQuery(UserRemoval.FIND_REMOVALS_TO_PROCESS, UserRemoval.class).getResultList();
-        return existingRemovalsToProcess.stream().map(UserRemoval::getUsername).collect(Collectors.toSet());
+        return existingRemovalsToProcess.stream().map(UserRemoval::getLdapUsername).collect(Collectors.toSet());
     }
 
     private void createUniqueUserRemoval(Set<String> existingUserNamesToProcess, String userName) {
@@ -203,7 +203,7 @@ public class LdapScanningBean {
         } else {
             logger.infof("Creating removal record for user %s", userName);
             UserRemoval removal = new UserRemoval();
-            removal.setUsername(userName);
+            removal.setLdapUsername(userName);
             em.persist(removal);
         }
     }

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/mail/report/RemovalsReportTable.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/mail/report/RemovalsReportTable.java
@@ -14,7 +14,7 @@ import static j2html.TagCreator.th;
 
 public class RemovalsReportTable implements ReportTable {
 
-    private static final String NAME_LABEL = "Username";
+    private static final String NAME_LABEL = "LDAP Username";
     private static final String CREATED_LABEL = "Created";
     private static final String STARTED_LABEL = "Started";
     private static final String STATUS_LABEL = "Status";
@@ -43,7 +43,7 @@ public class RemovalsReportTable implements ReportTable {
         SimpleDateFormat noMillisFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 
         return each(removals, removal -> tr(
-                td(removal.getUsername()).withStyle(Styles.TD_STYLE),
+                td(removal.getLdapUsername()).withStyle(Styles.TD_STYLE),
                 td(noMillisFormat.format(removal.getCreated())).withStyle(Styles.TD_STYLE),
                 td(noMillisFormat.format(removal.getStarted())).withStyle(Styles.TD_STYLE),
                 RemovalStatus.COMPLETED.equals(removal.getStatus()) ?

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/mail/report/RemovalsReportTable.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/mail/report/RemovalsReportTable.java
@@ -14,7 +14,8 @@ import static j2html.TagCreator.th;
 
 public class RemovalsReportTable implements ReportTable {
 
-    private static final String NAME_LABEL = "LDAP Username";
+    private static final String LDAP_NAME_LABEL = "LDAP Name";
+    private static final String GH_NAME_LABEL = "GH Name";
     private static final String CREATED_LABEL = "Created";
     private static final String STARTED_LABEL = "Started";
     private static final String STATUS_LABEL = "Status";
@@ -29,7 +30,8 @@ public class RemovalsReportTable implements ReportTable {
                 p("...performed during the last week").withStyle(Styles.SUB_HEADING_STYLE),
                 table().withStyle(Styles.TABLE_STYLE + Styles.TD_STYLE).with(
                         tr().with(
-                                th(NAME_LABEL).withStyle(Styles.TH_STYLE),
+                                th(LDAP_NAME_LABEL).withStyle(Styles.TH_STYLE),
+                                th(GH_NAME_LABEL).withStyle(Styles.TH_STYLE),
                                 th(CREATED_LABEL).withStyle(Styles.TH_STYLE),
                                 th(STARTED_LABEL).withStyle(Styles.TH_STYLE),
                                 th(STATUS_LABEL).withStyle(Styles.TH_STYLE)
@@ -43,7 +45,8 @@ public class RemovalsReportTable implements ReportTable {
         SimpleDateFormat noMillisFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 
         return each(removals, removal -> tr(
-                td(removal.getLdapUsername()).withStyle(Styles.TD_STYLE),
+                td(ReportUtils.stringOrEmpty(removal.getLdapUsername())).withStyle(Styles.TD_STYLE),
+                td(ReportUtils.stringOrEmpty(removal.getGithubUsername())).withStyle(Styles.TD_STYLE),
                 td(noMillisFormat.format(removal.getCreated())).withStyle(Styles.TD_STYLE),
                 td(noMillisFormat.format(removal.getStarted())).withStyle(Styles.TD_STYLE),
                 RemovalStatus.COMPLETED.equals(removal.getStatus()) ?

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/mail/report/ReportUtils.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/mail/report/ReportUtils.java
@@ -5,6 +5,9 @@ public final class ReportUtils {
     private ReportUtils() {
     }
 
+    /**
+     * Returns given string if it's not null, otherwise returns empty string.
+     */
     public static String stringOrEmpty(String str) {
         return str == null ? "" : str;
     }

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBeanTestCase.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBeanTestCase.java
@@ -128,7 +128,7 @@ public class LdapScanningBeanTestCase {
         // check removals were created
         List<UserRemoval> removals = query.getResultList();
         assertThat(removals)
-                .extracting("username")
+                .extracting("ldapUsername")
                 .containsOnly("ben", "bob");
 
         // create the same removals again
@@ -138,7 +138,7 @@ public class LdapScanningBeanTestCase {
         removals = query.getResultList();
         assertThat(removals.size()).isEqualTo(2);
         assertThat(removals)
-                .extracting("username")
+                .extracting("ldapUsername")
                 .containsOnly("ben", "bob");
     }
 
@@ -212,7 +212,7 @@ public class LdapScanningBeanTestCase {
         TypedQuery<UserRemoval> query = em.createNamedQuery(UserRemoval.FIND_REMOVALS_TO_PROCESS, UserRemoval.class);
         List<UserRemoval> removals = query.getResultList();
         assertThat(removals)
-                .extracting("username")
+                .extracting("ldapUsername")
                 .containsOnly("ben", "bob");
     }
 
@@ -226,7 +226,7 @@ public class LdapScanningBeanTestCase {
         TypedQuery<UserRemoval> query = em.createNamedQuery(UserRemoval.FIND_REMOVALS_TO_PROCESS, UserRemoval.class);
         List<UserRemoval> removals = query.getResultList();
         assertThat(removals)
-                .extracting("username")
+                .extracting("ldapUsername")
                 .containsOnly("ben", "bob");
     }
 
@@ -244,7 +244,7 @@ public class LdapScanningBeanTestCase {
         List<UserRemoval> removals = query.getResultList();
         assertThat(removals.size()).isEqualTo(2);
         assertThat(removals)
-                .extracting("username")
+                .extracting("ldapUsername")
                 .containsOnly("ben", "bob");
     }
 
@@ -266,7 +266,7 @@ public class LdapScanningBeanTestCase {
 
     private void createUserRemoval(String username) {
         UserRemoval userRemoval = new UserRemoval();
-        userRemoval.setUsername(username);
+        userRemoval.setLdapUsername(username);
 
         em.getTransaction().begin();
         em.persist(userRemoval);

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/mail/RemovalsReportBeanTestCase.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/mail/RemovalsReportBeanTestCase.java
@@ -87,7 +87,7 @@ public class RemovalsReportBeanTestCase {
 
         assertThat(lastFinishedRemovals.size()).isEqualTo(6);
         assertThat(lastFinishedRemovals)
-                .extracting("username", "status")
+                .extracting("ldapUsername", "status")
                 .containsOnly(
                         tuple("user6", RemovalStatus.UNKNOWN_USER),
                         tuple("user7", RemovalStatus.UNKNOWN_USER),

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/mail/report/RemovalsReportTableTestCase.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/mail/report/RemovalsReportTableTestCase.java
@@ -56,6 +56,9 @@ public class RemovalsReportTableTestCase {
         userRemoval = createUserRemoval("User2", oneDayLater, oneDayLater, RemovalStatus.FAILED);
         em.persist(userRemoval);
 
+        userRemoval = createUserRemoval(null, "ghUser", oneDayLater, oneDayLater, RemovalStatus.FAILED);
+        em.persist(userRemoval);
+
         em.getTransaction().commit();
     }
 
@@ -69,16 +72,26 @@ public class RemovalsReportTableTestCase {
         Document doc = Jsoup.parse(messageBody);
 
         assertThat(doc.select("tr").size()).isEqualTo(lastFinishedRemovals.size() + 1);
-        assertThat(doc.select("th").text()).isEqualTo("LDAP Username Created Started Status");
+        assertThat(doc.select("th").text()).isEqualTo("LDAP Name GH Name Created Started Status");
 
+        final int columnsInRow = 5;
         Elements elements = doc.select("td");
-        assertThat(elements.size()).isEqualTo(lastFinishedRemovals.size() * 4);
+        assertThat(elements.size()).isEqualTo(lastFinishedRemovals.size() * columnsInRow);
 
         for (int i = 0; i < lastFinishedRemovals.size(); i++) {
-            assertThat(elements.get((i * 4)).childNode(0).toString()).isEqualTo(lastFinishedRemovals.get(i).getLdapUsername());
-            assertThat(elements.get((i * 4) + 1).childNode(0).toString()).isEqualTo(noMillisFormat.format(lastFinishedRemovals.get(i).getCreated()));
-            assertThat(elements.get((i * 4) + 2).childNode(0).toString()).isEqualTo(noMillisFormat.format(lastFinishedRemovals.get(i).getStarted()));
-            assertThat(elements.get((i * 4) + 3).childNode(0).toString()).isEqualTo(lastFinishedRemovals.get(i).getStatus().toString());
+            if (lastFinishedRemovals.get(i).getLdapUsername() != null) {
+                assertThat(elements.get((i * columnsInRow)).childNode(0).toString()).isEqualTo(lastFinishedRemovals.get(i).getLdapUsername());
+            } else {
+                assertThat(elements.get((i * columnsInRow)).childNodeSize()).isEqualTo(0);
+            }
+            if (lastFinishedRemovals.get(i).getGithubUsername() != null) {
+                assertThat(elements.get((i * columnsInRow) + 1).childNode(0).toString()).isEqualTo(lastFinishedRemovals.get(i).getGithubUsername());
+            } else {
+                assertThat(elements.get((i * columnsInRow) + 1).childNodeSize()).isEqualTo(0);
+            }
+            assertThat(elements.get((i * columnsInRow) + 2).childNode(0).toString()).isEqualTo(noMillisFormat.format(lastFinishedRemovals.get(i).getCreated()));
+            assertThat(elements.get((i * columnsInRow) + 3).childNode(0).toString()).isEqualTo(noMillisFormat.format(lastFinishedRemovals.get(i).getStarted()));
+            assertThat(elements.get((i * columnsInRow) + 4).childNode(0).toString()).isEqualTo(lastFinishedRemovals.get(i).getStatus().toString());
         }
     }
 }

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/mail/report/RemovalsReportTableTestCase.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/mail/report/RemovalsReportTableTestCase.java
@@ -69,13 +69,13 @@ public class RemovalsReportTableTestCase {
         Document doc = Jsoup.parse(messageBody);
 
         assertThat(doc.select("tr").size()).isEqualTo(lastFinishedRemovals.size() + 1);
-        assertThat(doc.select("th").text()).isEqualTo("Username Created Started Status");
+        assertThat(doc.select("th").text()).isEqualTo("LDAP Username Created Started Status");
 
         Elements elements = doc.select("td");
         assertThat(elements.size()).isEqualTo(lastFinishedRemovals.size() * 4);
 
         for (int i = 0; i < lastFinishedRemovals.size(); i++) {
-            assertThat(elements.get((i * 4)).childNode(0).toString()).isEqualTo(lastFinishedRemovals.get(i).getUsername());
+            assertThat(elements.get((i * 4)).childNode(0).toString()).isEqualTo(lastFinishedRemovals.get(i).getLdapUsername());
             assertThat(elements.get((i * 4) + 1).childNode(0).toString()).isEqualTo(noMillisFormat.format(lastFinishedRemovals.get(i).getCreated()));
             assertThat(elements.get((i * 4) + 2).childNode(0).toString()).isEqualTo(noMillisFormat.format(lastFinishedRemovals.get(i).getStarted()));
             assertThat(elements.get((i * 4) + 3).childNode(0).toString()).isEqualTo(lastFinishedRemovals.get(i).getStatus().toString());

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/umb/EmployeeOffBoardEventsMDBTestCase.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/umb/EmployeeOffBoardEventsMDBTestCase.java
@@ -92,7 +92,7 @@ public class EmployeeOffBoardEventsMDBTestCase {
         List<UserRemoval> removals = findRemovalsQuery.getResultList();
         assertThat(removals.size()).isEqualTo(1);
         assertThat(removals)
-                .extracting("username")
+                .extracting("ldapUsername")
                 .containsOnly("lvydra");
     }
 }

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/util/TestUtils.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/util/TestUtils.java
@@ -59,14 +59,19 @@ public final class TestUtils {
                 StandardCharsets.UTF_8.name());
     }
 
-    public static UserRemoval createUserRemoval(String user, Timestamp timeStarted, Timestamp timeCompleted, RemovalStatus status) throws NoSuchFieldException, IllegalAccessException {
+    public static UserRemoval createUserRemoval(String ldapName, Timestamp timeStarted, Timestamp timeCompleted, RemovalStatus status) throws NoSuchFieldException, IllegalAccessException {
+        return createUserRemoval(ldapName, null, timeStarted, timeCompleted, status);
+    }
+
+    public static UserRemoval createUserRemoval(String ldapName, String ghName, Timestamp timeStarted, Timestamp timeCompleted, RemovalStatus status) throws NoSuchFieldException, IllegalAccessException {
         Field completedField = UserRemoval.class.getDeclaredField("completed");
         completedField.setAccessible(true);
         Field statusField = UserRemoval.class.getDeclaredField("status");
         statusField.setAccessible(true);
 
         UserRemoval userRemoval = new UserRemoval();
-        userRemoval.setLdapUsername(user);
+        userRemoval.setLdapUsername(ldapName);
+        userRemoval.setGithubUsername(ghName);
         userRemoval.setStarted(timeStarted);
 
         completedField.set(userRemoval, timeCompleted);

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/util/TestUtils.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/util/TestUtils.java
@@ -66,7 +66,7 @@ public final class TestUtils {
         statusField.setAccessible(true);
 
         UserRemoval userRemoval = new UserRemoval();
-        userRemoval.setUsername(user);
+        userRemoval.setLdapUsername(user);
         userRemoval.setStarted(timeStarted);
 
         completedField.set(userRemoval, timeCompleted);

--- a/dbscripts/create.sql
+++ b/dbscripts/create.sql
@@ -7,7 +7,8 @@ create table user_removals (
     remove_on date,
     started timestamp,
     status varchar(255),
-    username varchar(255)
+    ldap_username varchar(255),
+    github_username varchar(255)
 );
 
 create sequence sq_repository_forks;

--- a/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/RemovalStatus.java
+++ b/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/RemovalStatus.java
@@ -25,5 +25,10 @@ public enum RemovalStatus {
     /**
      * The removal process failed.
      */
-    FAILED
+    FAILED,
+
+    /**
+     * Invalid removal record.
+     */
+    INVALID
 }

--- a/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/UserRemoval.java
+++ b/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/UserRemoval.java
@@ -42,7 +42,11 @@ public class UserRemoval {
     @SuppressWarnings("unused")
     private Long id;
 
-    private String username;
+    @Column(name = "ldap_username")
+    private String ldapUsername;
+
+    @Column(name = "github_username")
+    private String githubUsername;
 
     /**
      * When should the membership be removed?
@@ -94,12 +98,20 @@ public class UserRemoval {
         this.started = started;
     }
 
-    public String getUsername() {
-        return username;
+    public String getLdapUsername() {
+        return ldapUsername;
     }
 
-    public void setUsername(String username) {
-        this.username = username;
+    public void setLdapUsername(String ldapUsername) {
+        this.ldapUsername = ldapUsername;
+    }
+
+    public String getGithubUsername() {
+        return githubUsername;
+    }
+
+    public void setGithubUsername(String githubUsername) {
+        this.githubUsername = githubUsername;
     }
 
     public Timestamp getCreated() {
@@ -133,5 +145,19 @@ public class UserRemoval {
 
     public void setLogs(List<RemovalLog> logs) {
         this.logs = logs;
+    }
+
+    @Override
+    public String toString() {
+        return "UserRemoval{" +
+                "id=" + id +
+                ", ldapUsername='" + ldapUsername + '\'' +
+                ", githubUsername='" + githubUsername + '\'' +
+                ", removeOn=" + removeOn +
+                ", created=" + created +
+                ", started=" + started +
+                ", completed=" + completed +
+                ", status=" + status +
+                '}';
     }
 }


### PR DESCRIPTION
This is so we could archive also unregistered users, currently a user must be registered for us to be able to archive him.

* Adds `user_removal.github_username` column
* Renames `user_removal.username` to `ldap_username`
* Adds `github_username` field into removals email report