### PR TITLE
SET-256 Only remove membership from managed teams

### DIFF
--- a/core/src/main/java/org/jboss/set/mjolnir/archive/batch/MembershipRemovalBatchlet.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/batch/MembershipRemovalBatchlet.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.egit.github.core.Repository;
 import org.jboss.logging.Logger;
 import org.jboss.set.mjolnir.archive.ArchivingBean;
+import org.jboss.set.mjolnir.archive.domain.GitHubTeam;
 import org.jboss.set.mjolnir.archive.github.GitHubDiscoveryBean;
 import org.jboss.set.mjolnir.archive.github.GitHubTeamServiceBean;
 import org.jboss.set.mjolnir.archive.configuration.Configuration;
@@ -47,7 +48,7 @@ public class MembershipRemovalBatchlet extends AbstractBatchlet {
     private ArchivingBean archivingBean;
 
     @Inject
-    private GitHubTeamServiceBean userRemovalBean;
+    private GitHubTeamServiceBean teamServiceBean;
 
     @Override
     public String process() {
@@ -208,10 +209,11 @@ public class MembershipRemovalBatchlet extends AbstractBatchlet {
             }
 
             // remove team memberships
-
+            logger.infof("User is about to be removed from following teams: %s",
+                    organization.getTeams().stream().map(GitHubTeam::getName).collect(Collectors.joining(", ")));
             if (configuration.isUnsubscribeUsers()) {
                 try {
-                    userRemovalBean.removeUserFromTeams(organization.getName(), gitHubUsername);
+                    teamServiceBean.removeUserFromTeams(organization, gitHubUsername);
                 } catch (IOException e) {
                     logError(removal, "Couldn't remove user membership from GitHub teams: " + gitHubUsername, e);
 
@@ -221,7 +223,7 @@ public class MembershipRemovalBatchlet extends AbstractBatchlet {
                     return false;
                 }
             } else {
-                logger.infof("User membership of user %s is not removed", gitHubUsername);
+                logger.infof("Membership removal is disabled, membership has not been removed.", gitHubUsername);
             }
         }
 

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBean.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBean.java
@@ -1,10 +1,10 @@
 package org.jboss.set.mjolnir.archive.ldap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.egit.github.core.Team;
 import org.eclipse.egit.github.core.User;
 import org.jboss.logging.Logger;
 import org.jboss.set.mjolnir.archive.domain.GitHubOrganization;
+import org.jboss.set.mjolnir.archive.domain.GitHubTeam;
 import org.jboss.set.mjolnir.archive.domain.RegisteredUser;
 import org.jboss.set.mjolnir.archive.domain.RemovalLog;
 import org.jboss.set.mjolnir.archive.domain.UserRemoval;
@@ -43,7 +43,7 @@ public class LdapScanningBean {
     private LdapDiscoveryBean ldapDiscoveryBean;
 
     @Inject
-    private GitHubTeamServiceBean gitHubBean;
+    private GitHubTeamServiceBean teamServiceBean;
 
     @Inject
     private RegisteredUserRepositoryBean userRepositoryBean;
@@ -121,7 +121,7 @@ public class LdapScanningBean {
 
         HashSet<User> users = new HashSet<>();
         for (GitHubOrganization organization : organizations) {
-            users.addAll(gitHubBean.getAllTeamsMembers(organization.getName()));
+            users.addAll(teamServiceBean.getAllTeamsMembers(organization));
         }
 
         return users.stream()
@@ -140,19 +140,19 @@ public class LdapScanningBean {
         return unregisteredMembers;
     }
 
-    public List<Team> getAllUsersTeams(String gitHubUser) throws IOException {
-        List<Team> memberTeams = new ArrayList<>();
+    public List<GitHubTeam> getAllUsersTeams(String gitHubUser) throws IOException {
+        List<GitHubTeam> memberTeams = new ArrayList<>();
 
         List<GitHubOrganization> organizations =
                 em.createNamedQuery(GitHubOrganization.FIND_ALL, GitHubOrganization.class).getResultList();
 
-        List<Team> allTeams = new ArrayList<>();
+        List<GitHubTeam> allTeams = new ArrayList<>();
         for (GitHubOrganization organization : organizations) {
-            allTeams.addAll(gitHubBean.getTeams(organization.getName()));
+            allTeams.addAll(organization.getTeams());
         }
 
-        for (Team team : allTeams) {
-            if (gitHubBean.isMember(gitHubUser, team))
+        for (GitHubTeam team : allTeams) {
+            if (teamServiceBean.isMember(gitHubUser, team))
                 memberTeams.add(team);
         }
 

--- a/core/src/main/java/org/jboss/set/mjolnir/archive/mail/report/UnregisteredMembersReportTable.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/mail/report/UnregisteredMembersReportTable.java
@@ -1,7 +1,7 @@
 package org.jboss.set.mjolnir.archive.mail.report;
 
 import j2html.tags.DomContent;
-import org.eclipse.egit.github.core.Team;
+import org.jboss.set.mjolnir.archive.domain.GitHubTeam;
 import org.jboss.set.mjolnir.archive.ldap.LdapScanningBean;
 
 import javax.inject.Inject;
@@ -48,7 +48,7 @@ public class UnregisteredMembersReportTable implements ReportTable {
         return html;
     }
 
-    private <T> DomContent addUnregisteredOrganizationMembersRows(Map<String, List<Team>> userTeams) {
+    private <T> DomContent addUnregisteredOrganizationMembersRows(Map<String, List<GitHubTeam>> userTeams) {
         return each(userTeams, userTeam -> tr(
                 td(userTeam.getKey()).withStyle(Styles.TD_STYLE),
                 td(
@@ -58,9 +58,9 @@ public class UnregisteredMembersReportTable implements ReportTable {
         ));
     }
 
-    private Map<String, List<Team>> getUnregisteredMembersWithTeams() throws IOException {
+    private Map<String, List<GitHubTeam>> getUnregisteredMembersWithTeams() throws IOException {
         Set<String> unregisteredOrganizationMembers = ldapScanningBean.getUnregisteredOrganizationMembers();
-        SortedMap<String, List<Team>> userTeams = new TreeMap<>(String::compareToIgnoreCase);
+        SortedMap<String, List<GitHubTeam>> userTeams = new TreeMap<>(String::compareToIgnoreCase);
         for (String member : unregisteredOrganizationMembers) {
             userTeams.put(member, ldapScanningBean.getAllUsersTeams(member));
         }

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/batch/MembershipRemovalBatchletTest.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/batch/MembershipRemovalBatchletTest.java
@@ -94,7 +94,7 @@ public class MembershipRemovalBatchletTest {
         assertThat(orgs.get(0).getName()).isEqualTo("testorg");
         assertThat(orgs.get(0).getTeams())
                 .extracting("name")
-                .containsOnly("Test Team", "Other Team");
+                .containsOnly("Team 1", "Team 2", "Team 3");
     }
 
     @Test

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBeanTestCase.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/ldap/LdapScanningBeanTestCase.java
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.deltaspike.core.util.ArraysUtils;
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
 import org.assertj.core.groups.Tuple;
-import org.eclipse.egit.github.core.Team;
+import org.jboss.set.mjolnir.archive.domain.GitHubTeam;
 import org.jboss.set.mjolnir.archive.domain.RegisteredUser;
 import org.jboss.set.mjolnir.archive.domain.UserRemoval;
 import org.junit.After;
@@ -56,12 +56,6 @@ public class LdapScanningBeanTestCase {
 
 
         // stubs for GitHub API endpoints
-
-        stubFor(get(urlPathEqualTo("/api/v3/orgs/testorg/teams"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(readSampleResponse("responses/gh-orgs-teams-response.json"))));
 
         stubFor(get(urlPathEqualTo("/api/v3/orgs/testorg/team/1/members"))
                 .willReturn(aResponse()
@@ -165,7 +159,7 @@ public class LdapScanningBeanTestCase {
     }
 
     @Test
-    public void testWhitelistedUsers() throws NamingException {
+    public void testWhitelistedUsers() {
         createRegisteredUser("bobNonExisting", "bob", true);
         createRegisteredUser("jimExisting", "jim", true);
         createRegisteredUser(null, "ben", true);
@@ -178,7 +172,7 @@ public class LdapScanningBeanTestCase {
     }
 
     @Test
-    public void testWhitelistedUsersCaseInsensitive() throws NamingException {
+    public void testWhitelistedUsersCaseInsensitive() {
         createRegisteredUser("bobNonExisting", "BOB", true);
         createRegisteredUser("jimExisting", "JIM", "responsible guy", true);
         createRegisteredUser(null, "BEN", true);
@@ -196,7 +190,7 @@ public class LdapScanningBeanTestCase {
 
     @Test
     public void testAllUsersTeams() throws IOException {
-        List<Team> teams = ldapScanningBean.getAllUsersTeams("bob");
+        List<GitHubTeam> teams = ldapScanningBean.getAllUsersTeams("bob");
         assertThat(teams)
                 .extracting("name")
                 .containsOnly("Team 1", "Team 3");

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/mail/report/UnregisteredMembershipTableTestCase.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/mail/report/UnregisteredMembershipTableTestCase.java
@@ -2,7 +2,7 @@ package org.jboss.set.mjolnir.archive.mail.report;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
-import org.eclipse.egit.github.core.Team;
+import org.jboss.set.mjolnir.archive.domain.GitHubTeam;
 import org.jboss.set.mjolnir.archive.domain.RegisteredUser;
 import org.jboss.set.mjolnir.archive.ldap.LdapScanningBean;
 import org.jsoup.Jsoup;
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jboss.set.mjolnir.archive.util.TestUtils.readSampleResponse;
 
@@ -40,11 +43,6 @@ public class UnregisteredMembershipTableTestCase {
 
     @Before
     public void setup() throws IOException, URISyntaxException {
-        stubFor(get(urlPathEqualTo("/api/v3/orgs/testorg/teams"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(readSampleResponse("responses/gh-orgs-teams-response.json"))));
 
         stubFor(get(urlPathEqualTo("/api/v3/orgs/testorg/team/1/members"))
                 .willReturn(aResponse()
@@ -91,7 +89,10 @@ public class UnregisteredMembershipTableTestCase {
     public void testComposeTableBody() throws IOException {
         final String testUser = "bob";
 
-        List<Team> testUserTeams = ldapScanningBean.getAllUsersTeams(testUser);
+        List<GitHubTeam> testUserTeams = ldapScanningBean.getAllUsersTeams(testUser);
+        assertThat(testUserTeams)
+                .extracting("name")
+                .containsOnly("Team 1", "Team 3");
 
         String messageBody = unregisteredMembersReportTable.composeTable();
         Document doc = Jsoup.parse(messageBody);

--- a/core/src/test/java/org/jboss/set/mjolnir/archive/mail/report/UsersWithoutLdapReportTableTestCase.java
+++ b/core/src/test/java/org/jboss/set/mjolnir/archive/mail/report/UsersWithoutLdapReportTableTestCase.java
@@ -51,12 +51,6 @@ public class UsersWithoutLdapReportTableTestCase {
 
     @Before
     public void setup() throws IOException, URISyntaxException, NamingException {
-        stubFor(get(urlPathEqualTo("/api/v3/orgs/testorg/teams"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "application/json")
-                        .withBody(readSampleResponse("responses/gh-orgs-teams-response.json"))));
-
         stubFor(get(urlPathEqualTo("/api/v3/orgs/testorg/team/1/members"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -100,6 +94,8 @@ public class UsersWithoutLdapReportTableTestCase {
     @Test
     public void testComposeTableBody() throws IOException, NamingException {
         List<String> users = ldapScanningBean.getUsersWithoutLdapAccount();
+        assertThat(users).containsOnly("ben", "bob");
+
         List<String> usersList = new ArrayList<>(users);
         usersList.sort(String::compareToIgnoreCase);
 

--- a/dbscripts/create.sql
+++ b/dbscripts/create.sql
@@ -3,7 +3,7 @@ create sequence sq_user_removals;
 create table user_removals (
     id bigint default nextval('sq_user_removals') primary key,
     completed timestamp,
-    created timestamp,
+    created timestamp default current_timestamp,
     remove_on date,
     started timestamp,
     status varchar(255),

--- a/dbscripts/load.sql
+++ b/dbscripts/load.sql
@@ -1,7 +1,8 @@
 insert into github_orgs values (1, 'testorg');
 
-insert into github_teams values (1, 1, 'Test Team', 3624929);
-insert into github_teams values (2, 1, 'Other Team', 3624949);
+insert into github_teams values (1, 1, 'Team 1', 1);
+insert into github_teams values (2, 1, 'Team 2', 2);
+insert into github_teams values (3, 1, 'Team 3', 3);
 
 insert into application_parameters (param_name, param_value) values ('github.token', '');
 insert into application_parameters (param_name, param_value) values ('application.reporting_email', 'info@example.com');

--- a/dbscripts/update-001.sql
+++ b/dbscripts/update-001.sql
@@ -1,0 +1,3 @@
+alter table user_removals add column ldap_username varchar(255);
+alter table user_removals add column github_username varchar(255);
+update user_removals set ldap_username = username;

--- a/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/GitHubTeam.java
+++ b/domain/src/main/java/org/jboss/set/mjolnir/archive/domain/GitHubTeam.java
@@ -29,7 +29,7 @@ public class GitHubTeam {
     private String name;
 
     @Column(name = "github_id", unique = true)
-    private Long githubId;
+    private Integer githubId;
 
     public GitHubTeam() {
     }
@@ -54,11 +54,11 @@ public class GitHubTeam {
         this.name = name;
     }
 
-    public Long getGithubId() {
+    public Integer getGithubId() {
         return githubId;
     }
 
-    public void setGithubId(Long githubId) {
+    public void setGithubId(Integer githubId) {
         this.githubId = githubId;
     }
 }


### PR DESCRIPTION
Currently we remove membership from all teams in managed GitHub orgs. With this change only memberships of teams specified in mjolnir database will be removed.