### PR TITLE
SET-261 Bug: Removals are not generated (based on UMB events)

### DIFF
--- a/core/src/main/java/org/jboss/set/mjolnir/archive/umb/EmployeeOffBoardEventsMDB.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/umb/EmployeeOffBoardEventsMDB.java
@@ -56,7 +56,7 @@ public class EmployeeOffBoardEventsMDB implements MessageListener {
 
         if (OFF_BOARD_EVENT.equals(event)) {
             JSONObject person = jsonObject.getJSONObject("person");
-            String kerberosName = person.getString("dn");
+            String kerberosName = person.getString("uid");
 
             logger.infof("Received offboard event for user %s.", kerberosName);
 


### PR DESCRIPTION
We take username from a wrong field - `dn` field contains fully qualified LDAP name, while `uid` field contains just LDAP username.