### PR TITLE
Make EmployeeOffBoardEventsMDB bind to JNDI queue name

### DIFF
--- a/core/src/main/java/org/jboss/set/mjolnir/archive/umb/EmployeeOffBoardEventsMDB.java
+++ b/core/src/main/java/org/jboss/set/mjolnir/archive/umb/EmployeeOffBoardEventsMDB.java
@@ -19,7 +19,8 @@ import java.util.Optional;
 
 @MessageDriven(name = "EmployeeOffBoardEventsMDB", activationConfig = {
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
-        @ActivationConfigProperty(propertyName = "destination", propertyValue = "Consumer.mjolnir.employees-events.VirtualTopic.services.enterprise-iam.integration.event"), // physical name
+        @ActivationConfigProperty(propertyName = "useJndi", propertyValue = "true"),
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:/queue/EmployeeEventsQueue"), // JNDI name
         @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge")})
 @ResourceAdapter(value = "activemq-rar.rar")
 public class EmployeeOffBoardEventsMDB implements MessageListener {


### PR DESCRIPTION
Bind EmployeeOffBoardEventsMDB to queue via JNDI name instead of physical name, in order to make it configurable. The queue physical name is environment dependent.

JNDI name is specified in admin-object defined in server configuration.