### PR TITLE
Minor Update in run-h2.sh

### DIFF
--- a/scripts/run-h2.sh
+++ b/scripts/run-h2.sh
@@ -13,5 +13,5 @@ if [ ! -f "$H2_JAR" ]; then
   wget "$H2_DOWNLOAD_URL" -P "$DB_DIR"
 fi
 
-cd "$DB_DIR"
+cd "$DB_DIR" || ! echo "Failure"
 java -cp "$JAR_NAME" org.h2.tools.Server


### PR DESCRIPTION
So here cd can fail for a variety of reasons: misspelled paths, missing directories, missing permissions, broken symlinks, and more.
If/when it does, the script will keep going and do all its operations in the wrong directory. This can be messy, especially if the operations involve creating or deleting a lot of files.